### PR TITLE
Restrict Streamlit UI to chat-based input

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@
 
 # <img src="https://github.com/Zongwei9888/Experiment_Images/raw/43c585dca3d21b8e4b6390d835cdd34dc4b4b23d/DeepCode_images/title_logo.svg" alt="DeepCode Logo" width="32" height="32" style="vertical-align: middle; margin-right: 8px;"/> DeepCode: Open Agentic Coding
 
-### *Advancing Code Generation with Multi-Agent Systems*
+### *Forked from HKUDS/DeepCode to Unlock Larger Codebase Generation*
+
+> This repository is an adaptation of the original [HKUDS/DeepCode](https://github.com/HKUDS/DeepCode) project. Our goal is to
+> modify the upstream agentic workflow wherever necessary so it can be opened up and scaled for generating substantially larger
+> codebases. All existing features remain available while we focus on the enhancements required for expansive code synthesis.
 
 <!-- <p align="center">
   <img src="https://img.shields.io/badge/Version-1.0.0-00d4ff?style=for-the-badge&logo=rocket&logoColor=white" alt="Version">

--- a/ui/components.py
+++ b/ui/components.py
@@ -843,7 +843,7 @@ def chat_input_component(task_counter: int) -> Optional[str]:
         "Enter your coding requirements:",
         placeholder="""Example: I want to build a web application that can analyze user sentiment from social media posts. The application should have:
 
-1. A user-friendly interface where users can input text or upload files
+1. A user-friendly interface where users can input text
 2. A machine learning backend that performs sentiment analysis
 3. Visualization of results with charts and statistics
 4. User authentication and data storage
@@ -904,36 +904,17 @@ def input_method_selector(task_counter: int) -> tuple[Optional[str], Optional[st
         unsafe_allow_html=True,
     )
 
-    # Input options
     st.markdown(
         """
     <p style="color: var(--text-secondary) !important; font-family: 'Inter', sans-serif !important; font-weight: 500 !important; margin-bottom: 1rem !important;">
-        Choose input method:
+        Describe your project below to begin a chat-based planning session.
     </p>
     """,
         unsafe_allow_html=True,
     )
 
-    input_method = st.radio(
-        "Choose your input method:",
-        ["📁 Upload File", "🌐 Enter URL", "💬 Chat Input"],
-        horizontal=True,
-        label_visibility="hidden",
-        key=f"input_method_{task_counter}",
-    )
-
-    input_source = None
-    input_type = None
-
-    if input_method == "📁 Upload File":
-        input_source = file_input_component(task_counter)
-        input_type = "file" if input_source else None
-    elif input_method == "🌐 Enter URL":
-        input_source = url_input_component(task_counter)
-        input_type = "url" if input_source else None
-    else:  # Chat input
-        input_source = chat_input_component(task_counter)
-        input_type = "chat" if input_source else None
+    input_source = chat_input_component(task_counter)
+    input_type = "chat" if input_source else None
 
     return input_source, input_type
 

--- a/ui/layout.py
+++ b/ui/layout.py
@@ -75,7 +75,7 @@ def render_input_interface():
         st.warning("⚠️ Do not refresh the page or close the browser during processing.")
 
     elif not input_source:
-        st.info("👆 Please upload a file or enter a URL to start processing.")
+        st.info("👆 Please describe your project requirements to start processing.")
 
 
 def render_sidebar():


### PR DESCRIPTION
## Summary
- simplify the input selector to present only the chat-based workflow
- update helper copy so the interface consistently directs users to describe their project requirements
- clarify the README introduction so this fork highlights its goal of unlocking larger codebase generation from DeepCode

## Testing
- python -m compileall ui

------
https://chatgpt.com/codex/tasks/task_e_68d2c2dc86a0832fba0bc34d27681ea7