### PR TITLE
Fix validators clean detection and prompt text

### DIFF
--- a/src/app/main.py
+++ b/src/app/main.py
@@ -157,7 +157,7 @@ def _generate_step3(project_name: str) -> None:
     _write_if_different(frontend_main_path, frontend_main_content)
 
     tokens_ts_path = root / "src/frontend/src/design-system/tokens.ts"
-    tokens_ts_content = """import { useEffect, useState } from 'react';\nimport designTokens from '../../../../ui/design_tokens.json';\n\nexport type DesignTokens = typeof designTokens;\n\nexport const tokens: DesignTokens = designTokens;\n\nexport function useDesignTokens(): DesignTokens {\n  const [state, setState] = useState<DesignTokens>(tokens);\n\n  useEffect(() => {\n    setState(tokens);\n  }, []);\n\n  return state;\n}\n\nexport function cssVariables(): Record<string, string> {\n  const vars: Record<string, string> = {};\n\n  for (const [groupName, groupValues] of Object.entries(tokens)) {\n    for (const [tokenName, tokenValue] of Object.entries(groupValues)) {\n      vars[`--dc-${groupName}-${tokenName}`] = tokenValue;\n    }\n  }\n\n  return vars;\n}\n"""
+    tokens_ts_content = """import { useEffect, useState } from 'react';\nimport designTokens from '../../../../ui/design_tokens.json';\n\nexport type DesignTokens = typeof designTokens;\n\nexport const tokens: DesignTokens = designTokens;\n\nexport function useDesignTokens(): DesignTokens {\n  const [state, setState] = useState<DesignTokens>(tokens);\n\n  useEffect(() => {\n    setState(tokens);\n  }, []);\n\n  return state;\n}\n\nexport function cssVariables(): Record<string, string> {\n  const vars: Record<string, string> = {};\n\n  for (const [groupName, groupValues] of Object.entries(tokens)) {\n    for (const [tokenName, tokenValue] of Object.entries(groupValues)) {\n      vars[`--dc-${groupName}-${tokenName}`] = tokenValue as string;\n    }\n  }\n\n  return vars;\n}\n"""
     _write_if_different(tokens_ts_path, tokens_ts_content)
 
     base_button_path = root / "src/frontend/src/design-system/BaseButton.tsx"
@@ -517,7 +517,7 @@ class ChatOrchestrator:
             "NEXT STEP",
             f"Awaiting response to: {prompt}",
             "PROMPT",
-            "Yes",
+            f"{prompt} (Yes/No)",
         ]
         return "\n".join(sections)
 

--- a/src/orchestrator/validators.py
+++ b/src/orchestrator/validators.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Dict, Iterable, List, Mapping
 
 from .required_outputs import required_for
@@ -53,7 +54,10 @@ class AgentValidationState:
 
     @property
     def is_clean(self) -> bool:
-        return all(result.exists and result.hash_matches for result in self.required_files)
+        return all(
+            result.exists and result.hash_matches and result.sections_valid
+            for result in self.required_files
+        )
 
 
 def _validate_sections(path: Path, expected_sections: Iterable[str]) -> bool:


### PR DESCRIPTION
## Summary
- ensure validator includes section content checks when determining clean/dirty state and import the missing Path helper
- align the generated tokens.ts scaffold with the runtime file by casting token values to strings
- present the current gate question directly in the PROMPT section to comply with the chat contract

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6861b8710832fac553285f300aad3