### PR TITLE
Fix Streamlit UI font family default syntax

### DIFF
--- a/ui/styles.py
+++ b/ui/styles.py
@@ -43,6 +43,8 @@ def _render_token_css() -> str:
     radius = tokens.get("radius", {})
     typography = tokens.get("typography", {})
 
+    font_family = typography.get("font_family", "'Inter', sans-serif")
+
     lines = [
         ":root {",
         f"    --dc-background: {colors.get('background', '#0a0e27')};",
@@ -60,7 +62,7 @@ def _render_token_css() -> str:
         f"    --dc-spacing-lg: {spacing.get('lg', '24px')};",
         f"    --dc-radius-sm: {radius.get('sm', '6px')};",
         f"    --dc-radius-md: {radius.get('md', '12px')};",
-        f"    --dc-font-family: {typography.get('font_family', "'Inter', sans-serif")};",
+        f"    --dc-font-family: {font_family};",
         "}",
         ".dc-app-shell {",
         "    background: linear-gradient(160deg, var(--dc-background) 0%, var(--dc-surface) 100%);",


### PR DESCRIPTION
## Summary
- resolve the f-string syntax error in `ui/styles.py` by caching the default font family value
- use the cached token value when rendering CSS variables

## Testing
- python -m compileall ui

------
https://chatgpt.com/codex/tasks/task_e_68d68869c4d4832faae9352ffb7e7f58